### PR TITLE
Add "zz", "{", "}", and "ESC" in visual mode.

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -43,6 +43,8 @@
 		]
 	},
 
+	{ "keys" : ["z", "z"], "command" : "center_on_cursor", "context": [] },
+
 	{ "keys": ["i"], "command": "enter_insert_mode", "context": [{"key": "setting.command_mode"}] },
 	{ "keys": ["I"], "command": "enter_insert_mode", "args":
 		{"insert_command": "vi_move_to_first_non_white_space_character"},

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -16,6 +16,14 @@
 		]
 	},
 
+	{ "keys": ["escape"], "command": "exit_visual_line_mode",
+		"context":
+		[
+			{ "key": "setting.command_mode" },
+			{ "key": "setting.is_widget", "operand": false }
+		]
+	},
+
 	{ "keys": ["ctrl+["], "command": "exit_insert_mode",
 		"context":
 		[

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -263,6 +263,17 @@
 	//
 	// Motions
 	//
+	{ "keys": ["{"], "command": "set_motion", "args": {
+		"motion": "move",
+		"motion_args": {"by": "stops", "word_begin": false, "empty_line": true, "separators": "", "forward": false, "extend": true }},
+		"context": [{"key": "setting.command_mode"}]
+	},
+
+	{ "keys": ["}"], "command": "set_motion", "args": {
+		"motion": "move",
+		"motion_args": {"by": "stops", "word_begin": false, "empty_line": true, "separators": "", "forward": true, "extend": true }},
+		"context": [{"key": "setting.command_mode"}]
+	},
 
 	{ "keys": ["W"], "command": "set_motion", "args": {
 		"motion": "move",

--- a/vintage.py
+++ b/vintage.py
@@ -897,6 +897,9 @@ class ReplaceCharacter(sublime_plugin.TextCommand):
         for s in new_sel:
             self.view.sel().add(s)
 
+class CenterOnCursor(sublime_plugin.TextCommand):
+    def run(self, edit):
+        self.view.show_at_center(self.view.sel()[0])
 
 class ViIndent(sublime_plugin.TextCommand):
     def run(self, edit):

--- a/vintage.py
+++ b/vintage.py
@@ -693,6 +693,14 @@ class EnterVisualLineMode(sublime_plugin.TextCommand):
         expand_to_full_line(self.view)
         self.view.run_command('maybe_mark_undo_groups_for_gluing')
 
+class ExitVisualLineMode(sublime_plugin.TextCommand):
+    def run(self, edit):
+        g_input_state.motion_mode = MOTION_MODE_NORMAL
+        set_motion_mode(self.view, MOTION_MODE_NORMAL)
+         
+        self.view.run_command('unmark_undo_groups_for_gluing')
+        self.view.run_command('shrink_selections')
+
 class ShrinkSelections(sublime_plugin.TextCommand):
     def shrink(self, r):
         if r.empty():


### PR DESCRIPTION
Minor details that make a big difference in usability, at least for me :) 

I've put the updates into `Default.sublime-keymap`, as it seems reasonable to assume that there will be no conflicts on other operating systems. I only have access to Linux though, so I can't be 100% sure.
