### PR TITLE
add z. and z<CR> commands

### DIFF
--- a/.hgignore
+++ b/.hgignore
@@ -1,6 +1,0 @@
-syntax: glob
-
-*.pyc
-
-*.sublime-project
-*.sublime-workspace

--- a/.hgignore
+++ b/.hgignore
@@ -1,0 +1,6 @@
+syntax: glob
+
+*.pyc
+
+*.sublime-project
+*.sublime-workspace

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -484,6 +484,19 @@
 		"context": [{"key": "setting.command_mode"}]
 	},
 
+ 	{ "keys": ["z", "."], "command": "set_motion", "args": {
+		"motion": "scroll_current_line_to_screen_center",
+ 		"motion_args": {"repeat": 1}},
+ 		"context": [{"key": "setting.command_mode"}]
+ 	},
+ 
+	{ "keys": ["z", "enter"], "command": "set_motion", "args": {
+		"motion": "scroll_current_line_to_screen_top",
+		"motion_args": {"repeat": 1}
+		},
+		"context": [{"key": "setting.command_mode"}]
+	},
+
 	// Motions to allow double press to mean entire line
 
 	{ "keys": ["c"], "command": "set_motion", "args": {

--- a/vintage_motions.py
+++ b/vintage_motions.py
@@ -264,3 +264,22 @@ class ViExpandToBrackets(sublime_plugin.TextCommand):
         self.view.run_command('expand_selection', {'to': 'brackets', 'brackets': character})
         if outer:
             self.view.run_command('expand_selection', {'to': 'brackets', 'brackets': character})
+
+class ScrollCurrentLineToScreenTop(sublime_plugin.TextCommand):
+    def run(self, edit, repeat, extend=False):
+        bos = self.view.visible_region().a
+        caret = self.view.line(self.view.sel()[0].begin()).a
+        offset = self.view.rowcol(caret)[0] - self.view.rowcol(bos)[0]
+
+        caret = advance_while_white_space_character(self.view, caret)
+        transform_selection(self.view, lambda pt: caret, extend)
+        self.view.run_command('scroll_lines', {'amount': -offset})
+
+class ScrollCurrentLineToScreenCenter(sublime_plugin.TextCommand):
+    def run(self, edit, repeat, extend=True):
+         line_nr = self.view.rowcol(self.view.sel()[0].a)[0] if \
+                                         int(repeat) == 1 else int(repeat) - 1
+         point = self.view.line(self.view.text_point(line_nr, 0)).a
+         point = advance_while_white_space_character(self.view, point)
+         transform_selection(self.view, lambda pt: point, extend)
+         self.view.run_command('show_at_center')


### PR DESCRIPTION
repeatedly calling z<CR> advances the current line one line down, whereas it shouldn't.
