### PR TITLE
Typing two consecutive z's in Insert mode was broken in the latest release

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -35,7 +35,7 @@
 		]
 	},
 
-	{ "keys" : ["z", "z"], "command" : "center_on_cursor", "context": [] },
+	{ "keys" : ["z", "z"], "command" : "center_on_cursor", "context": [{"key": "setting.command_mode"}] },
 
 	{ "keys": ["i"], "command": "enter_insert_mode", "context": [{"key": "setting.command_mode"}] },
 	{ "keys": ["I"], "command": "enter_insert_mode", "args":


### PR DESCRIPTION
With vintage mode enabled but in INSERT mode this had taken over typing two consecutive z's
