### PR TITLE
Updates for "_", "<", and ">"

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -573,7 +573,10 @@
 		]
 	},
 
-	{ "keys": [">"], "command": "set_motion", "args": {"motion": null},
+	{ "keys": [">"], "command": "set_motion", "args": {
+		"motion": "expand_selection",
+		"motion_args": {"to": "line" },
+		"mode": "normal"},
 		"context":
 		[
 			{"key": "setting.command_mode"},
@@ -581,7 +584,10 @@
 		]
 	},
 
-	{ "keys": ["<"], "command": "set_motion", "args": {"motion": null},
+	{ "keys": ["<"], "command": "set_motion", "args": {
+		"motion": "expand_selection",
+		"motion_args": {"to": "line" },
+		"mode": "normal"},
 		"context":
 		[
 			{"key": "setting.command_mode"},

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -391,6 +391,13 @@
 		"context": [{"key": "setting.command_mode"}]
 	},
 
+	{ "keys": ["_"], "command": "set_motion", "args": {
+		"motion": "vi_move_to_first_non_white_space_character",
+		"motion_args": {"extend": true },
+		"clip_to_line": true },
+		"context": [{"key": "setting.command_mode"}]
+	},
+
 	{ "keys": [" "], "command": "set_motion", "args": {
 		"motion": "vi_move_by_characters",
 		"motion_args": {"forward": true, "extend": true, "visual": false },


### PR DESCRIPTION
I've added a key mapping for `_`, which is identical to `^`, i.e., it moves the cursor to the first nonwhitespace character in the line.  This works in vim, and I find it more convenient than hitting `^`.  I simply copied the settings for `^` in the keymap file; I'm not sure if there is a better way to set multiple keys to have the same settings.

For `<` and `>`, a command like `n>>` will indent n lines one time in vim. Currently in Vintage, this will indent the current line n times. I changed the settings for these to be like `d` or `y`, and it seems to be working fine for me.

These were my two biggest annoyances with using Vintage mode instead of vim, so I thought I'd submit the changes to you guys in case anyone else wants them.  Feel free to let me know if there's a better way to do something, as I'm not very familiar with the code yet.
