### PR TITLE
enabling half page motion commands as on Vim (ctrl + d / ctrl + u)

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -486,6 +486,18 @@
 		"context": [{"key": "setting.command_mode"}, {"key": "setting.vintage_ctrl_keys"}]
 	},
 
+	{ "keys": ["ctrl+d"], "command": "set_motion", "args": {
+		"motion": "move_caret_half_page",
+		"motion_args": {"forward": true, "extend": true}},
+		"context": [{"key": "setting.command_mode"}, {"key": "setting.vintage_ctrl_keys"}]
+	},
+
+	{ "keys": ["ctrl+u"], "command": "set_motion", "args": {
+		"motion": "move_caret_half_page",
+		"motion_args": {"forward": false, "extend": true}},
+		"context": [{"key": "setting.command_mode"}, {"key": "setting.vintage_ctrl_keys"}]
+	},
+
 	{ "keys": ["H"], "command": "set_motion", "args": {
 		"motion": "move_caret_to_screen_top",
 		"motion_args": {"repeat": 1}},

--- a/vintage_motions.py
+++ b/vintage_motions.py
@@ -142,6 +142,28 @@ def advance_while_white_space_character(view, pt, white_space="\t "):
 
     return pt
 
+class MoveCaretHalfPage(sublime_plugin.TextCommand):
+    def run(self, edit, forward = True, extend = False):
+        screenful = self.view.visible_region()
+
+        row_a = self.view.rowcol(screenful.a)[0]
+        row_b = self.view.rowcol(screenful.b)[0]
+
+        page = row_b - row_a
+
+        if not forward:
+            page *= -1
+
+        half_page = page / 2
+
+        current_sel = self.view.sel()[0]
+        current_position = current_sel.b
+        row, col = self.view.rowcol(current_position)
+        target_point = self.view.text_point(row + half_page, col)
+
+        transform_selection(self.view, lambda pt: target_point, extend=extend)
+        self.view.show(target_point)
+
 class MoveCaretToScreenCenter(sublime_plugin.TextCommand):
     def run(self, edit, extend = True):
         screenful = self.view.visible_region()


### PR DESCRIPTION
I really use that ones, really missed when started using Vintage, but now I made it work, should be useful for other Vim users too.
