### PR TITLE
Fix (the second part) of issue #10 

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -211,8 +211,7 @@
 
 	{ "keys": ["d"], "command": "set_action", "args": {
 		"action": "vi_delete",
-		"description": "Delete",
-		"motion_mode": "auto_line"},
+		"description": "Delete"},
 		"context": [{"key": "setting.command_mode"}]
 	},
 


### PR DESCRIPTION
Fixes using the d command when having a selection that spans part of multiple lines, such as http://cl.ly/462X1G2k0c1M143f1Y1N - The current incorrect behavior is to delete both lines in their entirety.
