### PR TITLE
`X` command

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -167,6 +167,12 @@
 		"context": [{"key": "setting.command_mode"}]
 	},
 
+	{ "keys": ["X"], "command": "set_action_motion", "args": {
+		"action": "vi_left_delete",
+		"motion": null },
+		"context": [{"key": "setting.command_mode"}]
+	},
+
 	{ "keys": ["x"], "command": "set_action_motion", "args": {
 		"action": "vi_right_delete",
 		"motion": null },

--- a/vintage.py
+++ b/vintage.py
@@ -738,6 +738,13 @@ class ViDelete(sublime_plugin.TextCommand):
         set_register(self.view, '1', forward=False)
         self.view.run_command('left_delete')
 
+class ViLeftDelete(sublime_plugin.TextCommand):
+    def run(self, edit, register = '"'):
+        set_register(self.view, register, forward=False)
+        set_register(self.view, '1', forward=False)
+        self.view.run_command('left_delete')
+        clip_empty_selection_to_line_contents(self.view)
+
 class ViRightDelete(sublime_plugin.TextCommand):
     def run(self, edit, register = '"'):
         set_register(self.view, register, forward=True)


### PR DESCRIPTION
To match Vim 100%, this shouldn't backspace over line endings, but this is a start
