### PR TITLE
_ should accept counts

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -399,7 +399,7 @@
 
 	{ "keys": ["_"], "command": "set_motion", "args": {
 		"motion": "vi_move_to_first_non_white_space_character",
-		"motion_args": {"extend": true },
+		"motion_args": {"extend": true, "repeat": 1 },
 		"clip_to_line": true },
 		"context": [{"key": "setting.command_mode"}]
 	},

--- a/vintage_motions.py
+++ b/vintage_motions.py
@@ -47,7 +47,11 @@ class ViMoveToFirstNonWhiteSpaceCharacter(sublime_plugin.TextCommand):
 
         return l.a + offset
 
-    def run(self, edit, extend = False):
+    def run(self, edit, repeat = 1, extend = False):
+        # According to Vim's help, _ moves count - 1 lines downward.
+        for i in xrange(repeat - 1):
+            self.view.run_command('move', {'by': 'lines', 'forward': True, 'extend': True})
+            
         transform_selection(self.view, lambda pt: self.first_character(pt),
             extend=extend)
 

--- a/vintage_motions.py
+++ b/vintage_motions.py
@@ -50,7 +50,7 @@ class ViMoveToFirstNonWhiteSpaceCharacter(sublime_plugin.TextCommand):
     def run(self, edit, repeat = 1, extend = False):
         # According to Vim's help, _ moves count - 1 lines downward.
         for i in xrange(repeat - 1):
-            self.view.run_command('move', {'by': 'lines', 'forward': True, 'extend': True})
+            self.view.run_command('move', {'by': 'lines', 'forward': True, 'extend': extend})
             
         transform_selection(self.view, lambda pt: self.first_character(pt),
             extend=extend)


### PR DESCRIPTION
I think this change won't affect other commands using vi_move_to_first_non_white_space_character.

According to Vim's help, _ should take counts and move count - 1 lines downward before repositioning the caret.
