### PR TITLE
Added default key binding for ctrl+c to escape insert mode

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -31,6 +31,25 @@
 			{ "key": "setting.command_mode"},
 			{ "key": "num_selections", "operand": 1},
 			{ "key": "selection_empty", "operator": "equal", "operand": false, "match_all": false },
+      { "key": "setting.vintage_ctrl_keys" }
+		]
+	},
+
+	{ "keys": ["ctrl+c"], "command": "exit_insert_mode",
+		"context":
+		[
+			{ "key": "setting.command_mode", "operand": false },
+			{ "key": "setting.is_widget", "operand": false },
+      { "key": "setting.vintage_ctrl_keys" }
+		]
+	},
+
+	{ "keys": ["ctrl+c"], "command": "exit_visual_mode",
+		"context":
+		[
+			{ "key": "setting.command_mode"},
+			{ "key": "num_selections", "operand": 1},
+			{ "key": "selection_empty", "operator": "equal", "operand": false, "match_all": false },
 			{ "key": "setting.vintage_ctrl_keys" }
 		]
 	},


### PR DESCRIPTION
Added default key binding for ctrl+c to escape insert mode, same as vim
