### PR TITLE
["r", "enter"] command that matches Vim's behavior

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -169,6 +169,11 @@
 
 	{ "keys": ["."], "command": "repeat", "context": [{"key": "setting.command_mode"}] },
 
+	{ "keys": ["r", "enter"], "command": "run_macro_file",
+		"args": {"file": "Packages/Vintage/Replace With Newline.sublime-macro"},
+		"context": [{"key": "setting.command_mode"}]
+	},
+
 	{ "keys": ["r", "<character>"], "command": "replace_character",
 		"context": [{"key": "setting.command_mode"}]
 	},

--- a/Replace With Newline.sublime-macro
+++ b/Replace With Newline.sublime-macro
@@ -1,0 +1,7 @@
+[
+	{"command": "replace_character", "args": {"character": "\n"}},
+	{"command": "split_selection_into_lines"},
+    {"command": "move", "args": {"by": "lines", "forward": true}},
+    {"command": "move_to", "args": {"to": "bol", "extend": false}},
+    {"command": "reindent", "args": {"force_indent": false}}
+]


### PR DESCRIPTION
Bonus: Multiple selections allows us to do something sane when using `["r", "enter"]` with from visual mode
