### PR TITLE
cancel current action in normal mode by pressing escape

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -23,6 +23,7 @@
         [
             { "key": "setting.command_mode" },
             { "key": "vi_has_action" },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": false },
             { "key": "setting.vintage_ctrl_keys" }
         ]
     },
@@ -32,6 +33,7 @@
         [
             { "key": "setting.command_mode" },
             { "key": "vi_has_repeat_digit" },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": false },
             { "key": "setting.vintage_ctrl_keys" }
         ]
     },
@@ -41,6 +43,7 @@
         [
             { "key": "setting.command_mode" },
             { "key": "vi_has_register" },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": false },
             { "key": "setting.vintage_ctrl_keys" }
         ]
     },

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -18,6 +18,33 @@
         ]
     },
 
+    { "keys": ["ctrl+c"], "command": "vi_cancel_current_action",
+        "context":
+        [
+            { "key": "setting.command_mode" },
+            { "key": "vi_has_action" },
+            { "key": "setting.vintage_ctrl_keys" }
+        ]
+    },
+
+    { "keys": ["ctrl+c"], "command": "vi_cancel_current_action",
+        "context":
+        [
+            { "key": "setting.command_mode" },
+            { "key": "vi_has_repeat_digit" },
+            { "key": "setting.vintage_ctrl_keys" }
+        ]
+    },
+
+    { "keys": ["ctrl+c"], "command": "vi_cancel_current_action",
+        "context":
+        [
+            { "key": "setting.command_mode" },
+            { "key": "vi_has_register" },
+            { "key": "setting.vintage_ctrl_keys" }
+        ]
+    },
+
     { "keys": ["left"], "command": "set_motion", "args": {
         "motion": "vi_move_by_characters_in_line",
         "motion_args": {"forward": false, "extend": true }},

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -25,6 +25,7 @@
 	{ "keys": ["escape"], "command": "vi_cancel_current_action", "context":
 		[
 			{ "key": "setting.command_mode" },
+			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": false },
 			{ "key": "vi_has_action" }
 		]
 	},
@@ -32,6 +33,7 @@
 	{ "keys": ["escape"], "command": "vi_cancel_current_action", "context":
 		[
 			{ "key": "setting.command_mode" },
+			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": false },
 			{ "key": "vi_has_repeat_digit" }
 		]
 	},
@@ -39,6 +41,7 @@
 	{ "keys": ["escape"], "command": "vi_cancel_current_action", "context":
 		[
 			{ "key": "setting.command_mode" },
+			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": false },
 			{ "key": "vi_has_register" }
 		]
 	},
@@ -66,6 +69,7 @@
 		[
 			{ "key": "setting.command_mode" },
 			{ "key": "vi_has_action" },
+			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": false },
 			{ "key": "setting.vintage_ctrl_keys" }
 		]
 	},
@@ -74,6 +78,7 @@
 		[
 			{ "key": "setting.command_mode" },
 			{ "key": "vi_has_repeat_digit" },
+			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": false },
 			{ "key": "setting.vintage_ctrl_keys" }
 		]
 	},
@@ -82,6 +87,7 @@
 		[
 			{ "key": "setting.command_mode" },
 			{ "key": "vi_has_register" },
+			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": false },
 			{ "key": "setting.vintage_ctrl_keys" }
 		]
 	},

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -22,6 +22,27 @@
 		]
 	},
 
+	{ "keys": ["escape"], "command": "vi_cancel_current_action", "context":
+		[
+			{ "key": "setting.command_mode" },
+			{ "key": "vi_has_action" }
+		]
+	},
+
+	{ "keys": ["escape"], "command": "vi_cancel_current_action", "context":
+		[
+			{ "key": "setting.command_mode" },
+			{ "key": "vi_has_repeat_digit" }
+		]
+	},
+
+	{ "keys": ["escape"], "command": "vi_cancel_current_action", "context":
+		[
+			{ "key": "setting.command_mode" },
+			{ "key": "vi_has_register" }
+		]
+	},
+
 	{ "keys": ["ctrl+["], "command": "exit_insert_mode",
 		"context":
 		[
@@ -37,6 +58,30 @@
 			{ "key": "setting.command_mode"},
 			{ "key": "num_selections", "operand": 1},
 			{ "key": "selection_empty", "operator": "equal", "operand": false, "match_all": false },
+			{ "key": "setting.vintage_ctrl_keys" }
+		]
+	},
+
+	{ "keys": ["ctrl+["], "command": "vi_cancel_current_action", "context":
+		[
+			{ "key": "setting.command_mode" },
+			{ "key": "vi_has_action" },
+			{ "key": "setting.vintage_ctrl_keys" }
+		]
+	},
+
+	{ "keys": ["ctrl+["], "command": "vi_cancel_current_action", "context":
+		[
+			{ "key": "setting.command_mode" },
+			{ "key": "vi_has_repeat_digit" },
+			{ "key": "setting.vintage_ctrl_keys" }
+		]
+	},
+
+	{ "keys": ["ctrl+["], "command": "vi_cancel_current_action", "context":
+		[
+			{ "key": "setting.command_mode" },
+			{ "key": "vi_has_register" },
 			{ "key": "setting.vintage_ctrl_keys" }
 		]
 	},

--- a/vintage.py
+++ b/vintage.py
@@ -88,6 +88,10 @@ def reset_input_state(view, reset_motion_mode = True):
     if reset_motion_mode:
         set_motion_mode(view, MOTION_MODE_NORMAL)
 
+class ViCancelCurrentAction(sublime_plugin.TextCommand):
+    def run(self, action, action_args = {}, motion_mode = None, description = None):
+        reset_input_state(self.view, True)
+
 def string_to_motion_mode(mode):
     if mode == 'normal':
         return MOTION_MODE_NORMAL
@@ -162,6 +166,10 @@ class InputStateTracker(sublime_plugin.EventListener):
             v = g_input_state.action_command is not None
             if operator == sublime.OP_EQUAL: return v == operand
             if operator == sublime.OP_NOT_EQUAL: return v != operand
+        elif key == "vi_has_register":
+            r = g_input_state.register is not None
+            if operator == sublime.OP_EQUAL: return r == operand
+            if operator == sublime.OP_NOT_EQUAL: return r != operand
         elif key == "vi_motion_mode":
             m = string_to_motion_mode(operand)
             if operator == sublime.OP_EQUAL:

--- a/vintage.py
+++ b/vintage.py
@@ -35,37 +35,35 @@ g_input_state = InputState()
 
 # Updates the status bar to reflect the current mode and input state
 def update_status_line(view):
-    cmd_mode = view.settings().get('command_mode')
+    desc = []
 
-    if cmd_mode and g_input_state.motion_mode == MOTION_MODE_LINE:
-        view.set_status('mode', 'VISUAL LINE MODE')
-    elif cmd_mode and view.has_non_empty_selection_region():
-        view.set_status('mode', 'VISUAL MODE')
-    elif cmd_mode:
-        desc = []
-        if g_input_state.register:
-            desc.append('Register "' + g_input_state.register + '"')
-
-        if g_input_state.action_command is not None:
-            if g_input_state.action_description:
-                desc.append(g_input_state.action_description)
-            else:
-                desc.append(g_input_state.action_command)
-
-        repeat = (digits_to_number(g_input_state.prefix_repeat_digits)
-            * digits_to_number(g_input_state.motion_repeat_digits))
-        if repeat != 1:
-            if g_input_state.action_command is not None:
-                desc[-1] += " * " + str(repeat)
-            else:
-                desc.append("* " + str(repeat))
-
-        if desc:
-            view.set_status('mode', 'COMMAND MODE - ' + ' - '.join(desc))
+    if view.settings().get('command_mode'):
+        if g_input_state.motion_mode == MOTION_MODE_LINE:
+            desc = ['VISUAL LINE MODE']
+        elif view.has_non_empty_selection_region():
+            desc = ['VISUAL MODE']
         else:
-            view.set_status('mode', 'COMMAND MODE')
+            desc = ['COMMAND MODE']
+            if g_input_state.action_command is not None:
+                if g_input_state.action_description:
+                    desc.append(g_input_state.action_description)
+                else:
+                    desc.append(g_input_state.action_command)
+
+            repeat = (digits_to_number(g_input_state.prefix_repeat_digits)
+                * digits_to_number(g_input_state.motion_repeat_digits))
+            if repeat != 1:
+                if g_input_state.action_command is not None:
+                    desc[-1] += " * " + str(repeat)
+                else:
+                    desc.append("* " + str(repeat))
+
+        if g_input_state.register is not None:
+            desc.insert(1, 'Register "' + g_input_state.register + '"')
     else:
-        view.set_status('mode', 'INSERT MODE')
+        desc = ['INSERT MODE']
+
+    view.set_status('mode', ' - '.join(desc))
 
 def set_motion_mode(view, mode):
     g_input_state.motion_mode = mode

--- a/vintage.py
+++ b/vintage.py
@@ -42,28 +42,26 @@ def update_status_line(view):
     elif cmd_mode and view.has_non_empty_selection_region():
         view.set_status('mode', 'VISUAL MODE')
     elif cmd_mode:
-        desc = None
+        desc = []
         if g_input_state.register:
-            desc = 'Register "' + g_input_state.register + '" - '
+            desc.append('Register "' + g_input_state.register + '"')
+
+        if g_input_state.action_command is not None:
+            if g_input_state.action_description:
+                desc.append(g_input_state.action_description)
+            else:
+                desc.append(g_input_state.action_command)
 
         repeat = (digits_to_number(g_input_state.prefix_repeat_digits)
             * digits_to_number(g_input_state.motion_repeat_digits))
-        if g_input_state.action_command is not None or repeat != 1:
-            cmd_desc = g_input_state.action_command
-            if g_input_state.action_description:
-                cmd_desc = g_input_state.action_description
-
-            if cmd_desc and desc:
-                desc += " "
-                desc += cmd_desc
-
-            if repeat != 1 and desc:
-                desc = desc + " * " + str(repeat)
-            elif repeat != 1:
-                desc = "* " + str(repeat)
+        if repeat != 1:
+            if g_input_state.action_command is not None:
+                desc[-1] += " * " + str(repeat)
+            else:
+                desc.append("* " + str(repeat))
 
         if desc:
-            view.set_status('mode', 'COMMAND MODE - ' + desc)
+            view.set_status('mode', 'COMMAND MODE - ' + ' - '.join(desc))
         else:
             view.set_status('mode', 'COMMAND MODE')
     else:


### PR DESCRIPTION
this is very handy when inadvertently pressing an action key, i.e. "d".
register and repeat count are also cleared (even if there is no command).

vim and BSD vi do the same thing, so i think this change is highly justified.
