### PR TITLE
Linewise motion fix

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -284,15 +284,13 @@
 
 	{ "keys": ["d"], "command": "set_action", "args": {
 		"action": "vi_delete",
-		"description": "Delete",
-		"motion_mode": "auto_line"},
+		"description": "Delete"},
 		"context": [{"key": "setting.command_mode"}]
 	},
 
 	{ "keys": ["y"], "command": "set_action", "args": {
 		"action": "vi_copy",
-		"description": "Yank",
-		"motion_mode": "auto_line"},
+		"description": "Yank"},
 		"context": [{"key": "setting.command_mode"}]
 	},
 
@@ -327,7 +325,7 @@
 		"context": [{"key": "setting.command_mode"}]
 	},
 
-	{ "keys": [">"], "command": "set_action", "args": {"action": "vi_indent", "description": "Indent", "motion_mode": "auto_line"},
+	{ "keys": [">"], "command": "set_action", "args": {"action": "vi_indent", "description": "Indent"},
 		"context": [{"key": "setting.command_mode"}]
 	},
 
@@ -467,6 +465,7 @@
 	{ "keys": ["_"], "command": "set_motion", "args": {
 		"motion": "vi_move_to_first_non_white_space_character",
 		"motion_args": {"extend": true, "repeat": 1 },
+		"linewise": true,
 		"clip_to_line": true },
 		"context": [{"key": "setting.command_mode"}]
 	},
@@ -503,25 +502,29 @@
 
 	{ "keys": ["j"], "command": "set_motion", "args": {
 		"motion": "move",
-		"motion_args": {"by": "lines", "forward": true, "extend": true }},
+		"motion_args": {"by": "lines", "forward": true, "extend": true },
+		"linewise": true },
 		"context": [{"key": "setting.command_mode"}]
 	},
 
 	{ "keys": ["k"], "command": "set_motion", "args": {
 		"motion": "move",
-		"motion_args": {"by": "lines", "forward": false, "extend": true }},
+		"motion_args": {"by": "lines", "forward": false, "extend": true },
+		"linewise": true },
 		"context": [{"key": "setting.command_mode"}]
 	},
 
 	{ "keys": ["G"], "command": "set_motion", "args": {
 		"motion": "vi_goto_line",
-		"motion_args": {"repeat": 1, "explicit_repeat": true, "extend": true }},
+		"motion_args": {"repeat": 1, "explicit_repeat": true, "extend": true },
+		"linewise": true },
 		"context": [{"key": "setting.command_mode"}]
 	},
 
 	{ "keys": ["g", "g"], "command": "set_motion", "args": {
 		"motion": "move_to",
-		"motion_args": {"to": "bof", "extend": true }},
+		"motion_args": {"to": "bof", "extend": true },
+		"linewise": true },
 		"context": [{"key": "setting.command_mode"}]
 	},
 
@@ -586,16 +589,19 @@
 
 	{ "keys": ["H"], "command": "set_motion", "args": {
 		"motion": "move_caret_to_screen_top",
-		"motion_args": {"repeat": 1}},
+		"motion_args": {"repeat": 1},
+		"linewise": true },
 		"context": [{"key": "setting.command_mode"}]
 	},
 	{ "keys": ["M"], "command": "set_motion", "args": {
-		"motion": "move_caret_to_screen_center"},
+		"motion": "move_caret_to_screen_center",
+		"linewise": true },
 		"context": [{"key": "setting.command_mode"}]
 	},
 	{ "keys": ["L"], "command": "set_motion", "args": {
 		"motion": "move_caret_to_screen_bottom",
-		"motion_args": {"repeat": 1}},
+		"motion_args": {"repeat": 1},
+		"linewise": true },
 		"context": [{"key": "setting.command_mode"}]
 	},
 

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -111,6 +111,13 @@
 			{"key": "vi_motion_mode", "operand": "line"}
 		]
 	},
+	{ "keys": ["V"], "command": "set_motion_mode", "args": {"mode": "line"},
+		"context":
+		[
+			{"key": "setting.command_mode"},
+			{"key": "vi_has_action" }
+		]
+	},
 
 	{ "keys": ["\"", "<character>"], "command": "set_register",
 		"context": [{"key": "setting.command_mode"}]

--- a/vintage.py
+++ b/vintage.py
@@ -5,9 +5,6 @@ import os.path
 MOTION_MODE_NORMAL = 0
 # Used in visual line mode: Motions are extended to BOL and EOL.
 MOTION_MODE_LINE = 2
-# Used by some actions, just as 'd'. If a motion crosses line boundaries,
-# it'll be extended to BOL and EOL
-MOTION_MODE_AUTO_LINE = 1
 
 # Registers are used for clipboards and macro storage
 g_registers = {}
@@ -27,6 +24,7 @@ class InputState:
     motion_command = None
     motion_command_args = None
     motion_mode = MOTION_MODE_NORMAL
+    motion_mode_overridden = False
     motion_inclusive = False
     motion_clip_to_line = False
     register = None
@@ -81,6 +79,7 @@ def reset_input_state(view, reset_motion_mode = True):
     g_input_state.action_description = None
     g_input_state.motion_repeat_digits = []
     g_input_state.motion_command = None
+    g_input_state.motion_mode_overridden = False
     g_input_state.motion_command_args = None
     g_input_state.motion_inclusive = False
     g_input_state.motion_clip_to_line = False
@@ -93,8 +92,6 @@ def string_to_motion_mode(mode):
         return MOTION_MODE_NORMAL
     elif mode == 'line':
         return MOTION_MODE_LINE
-    elif mode == 'auto_line':
-        return MOTION_MODE_AUTO_LINE
     else:
         return -1
 
@@ -240,22 +237,11 @@ class SetAction(sublime_plugin.TextCommand):
 
         return self.run(**args)
 
-    def run(self, action, action_args = {}, motion_mode = None, description = None):
+    def run(self, action, action_args = {}, description = None):
         global g_input_state
         g_input_state.action_command = action
         g_input_state.action_command_args = action_args
         g_input_state.action_description = description
-
-        if motion_mode is not None:
-            m = string_to_motion_mode(motion_mode)
-            if m != -1:
-                if g_input_state.motion_mode == MOTION_MODE_LINE and m == MOTION_MODE_AUTO_LINE:
-                    # e.g., 'Vjd', MOTION_MODE_LINE should be maintained
-                    pass
-                else:
-                    set_motion_mode(self.view, m)
-            else:
-                print "invalid motion mode:", motion_mode
 
         if self.view.has_non_empty_selection_region():
             # Currently in visual mode, so no following motion is expected:
@@ -283,7 +269,7 @@ class SetMotion(sublime_plugin.TextCommand):
     def run_(self, args):
         return self.run(**args)
 
-    def run(self, motion, motion_args = {}, inclusive = False,
+    def run(self, motion, motion_args = {}, linewise = False, inclusive = False,
             clip_to_line = False, character = None, mode = None):
 
         global g_input_state
@@ -297,6 +283,10 @@ class SetMotion(sublime_plugin.TextCommand):
         g_input_state.motion_command_args = motion_args
         g_input_state.motion_inclusive = inclusive
         g_input_state.motion_clip_to_line = clip_to_line
+        if not g_input_state.motion_mode_overridden \
+                and g_input_state.action_command \
+                and linewise:
+            g_input_state.motion_mode = MOTION_MODE_LINE
 
         if mode is not None:
             m = string_to_motion_mode(mode)
@@ -343,6 +333,7 @@ class SetMotionMode(sublime_plugin.TextCommand):
 
         if m != -1:
             set_motion_mode(self.view, m)
+            g_input_state.motion_mode_overridden = True
         else:
             print "invalid motion mode"
 
@@ -455,31 +446,6 @@ def orient_single_character_region(view, forward, r):
 def set_single_character_selection_direction(view, forward):
     transform_selection_regions(view,
         lambda r: orient_single_character_region(view, forward, r))
-
-def expand_line_spanning_selections_to_line(view):
-    new_sel = []
-    for s in view.sel():
-        if s.a == s.b:
-            new_sel.append(s)
-            continue
-
-        la = view.full_line(s.a)
-        lb = view.full_line(s.b)
-
-        if la == lb:
-            new_sel.append(s)
-        elif s.a < s.b:
-            a = la.a
-            b = lb.b
-            new_sel.append(sublime.Region(a, b))
-        else:
-            a = la.b
-            b = lb.a
-            new_sel.append(sublime.Region(a, b))
-
-    view.sel().clear()
-    for s in new_sel:
-        view.sel().add(s)
 
 def clip_empty_selection_to_line_contents(view):
     new_sel = []
@@ -619,8 +585,6 @@ class ViEval(sublime_plugin.TextCommand):
 
             if motion_mode == MOTION_MODE_LINE:
                 expand_to_full_line(self.view)
-            elif motion_mode == MOTION_MODE_AUTO_LINE:
-                expand_line_spanning_selections_to_line(self.view)
 
             if action_command:
                 # Apply the action to the selection

--- a/vintage.py
+++ b/vintage.py
@@ -586,6 +586,9 @@ class ViEval(sublime_plugin.TextCommand):
             if motion_mode == MOTION_MODE_LINE:
                 expand_to_full_line(self.view, visual_mode)
                 if action_command == "enter_insert_mode":
+                    # When lines are deleted before entering insert mode, the
+                    # cursor should be left on an empty line. Leave the trailing
+                    # newline out of the selection to allow for this.
                     transform_selection_regions(self.view,
                         lambda r: sublime.Region(r.begin(), r.end() - 1))
 

--- a/vintage.py
+++ b/vintage.py
@@ -585,6 +585,9 @@ class ViEval(sublime_plugin.TextCommand):
 
             if motion_mode == MOTION_MODE_LINE:
                 expand_to_full_line(self.view, visual_mode)
+                if action_command == "enter_insert_mode":
+                    transform_selection_regions(self.view,
+                        lambda r: sublime.Region(r.begin(), r.end() - 1))
 
             if action_command:
                 # Apply the action to the selection

--- a/vintage.py
+++ b/vintage.py
@@ -394,7 +394,7 @@ def transform_selection_regions(view, f):
     for r in new_sel:
         sel.add(r)
 
-def expand_to_full_line(view):
+def expand_to_full_line(view, ignore_trailing_newline = True):
     new_sel = []
     for s in view.sel():
         if s.a == s.b:
@@ -405,7 +405,7 @@ def expand_to_full_line(view):
 
             a = la.a
 
-            if s.end() == lb.a:
+            if ignore_trailing_newline and s.end() == lb.a:
                 # s.end() is already at EOL, don't go down to the next line
                 b = s.end()
             else:
@@ -584,7 +584,7 @@ class ViEval(sublime_plugin.TextCommand):
                 transform_selection_regions(self.view, lambda r: self.view.split_by_newlines(r)[0])
 
             if motion_mode == MOTION_MODE_LINE:
-                expand_to_full_line(self.view)
+                expand_to_full_line(self.view, visual_mode)
 
             if action_command:
                 # Apply the action to the selection


### PR DESCRIPTION
From the vimdocs http://vimdoc.sourceforge.net/htmldoc/motion.html#operator:

```
                        *linewise* *characterwise*
The operator either affects whole lines, or the characters between the start
and end position.  Generally, motions that move between lines affect lines
(are linewise), and motions that move within a line affect characters (are
characterwise).  However, there are some exceptions.
```

On master, when using an action/operator with a motion that spans multiple lines the action will act on entire lines (linewise).  We can't, however, guess if a motion is linewise.  This pull fixes this by marking all motions that should be linewise as such (the vimdocs specify whether a motion is linewise or not).  Only those motions will automatically act on entire lines.  For instance, `dj` will delete two full lines but `di{` will only delete what's between the braces (even if that spans multiple lines) because `j` is a linewise motion and `i{` is not.

Also, _all_ actions/operators should act on entire lines if they're used with a linewise motion.  So the `"auto_line"` configuration was pull out of `SetAction`.  This behavior matches Vim.

This pull fixes the issues with my previous one (#36) and fixes #10 and #22
