### PR TITLE
Linewise changes reindent if 'auto_indent' is set

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -678,8 +678,8 @@
 	// Motions to allow double press to mean entire line
 
 	{ "keys": ["c"], "command": "set_motion", "args": {
-		"motion": "expand_selection",
-		"motion_args": {"to": "line_without_eol" }},
+		"motion": "vi_dont_move",
+		"linewise": true},
 		"context":
 		[
 			{"key": "setting.command_mode"},
@@ -778,8 +778,8 @@
 	{ "keys": ["S"], "command": "set_action_motion", "args": {
 		"action": "enter_insert_mode",
 		"action_args": {"insert_command": "vi_delete"},
-		"motion": "expand_selection",
-		"motion_args": {"to": "line_without_eol" }},
+		"motion": "vi_dont_move",
+		"motion_linewise": true},
 		"context": [{"key": "setting.command_mode"}]
 	},
 

--- a/vintage_motions.py
+++ b/vintage_motions.py
@@ -2,6 +2,10 @@ import sublime, sublime_plugin
 from vintage import transform_selection
 from vintage import transform_selection_regions
 
+class ViDontMove(sublime_plugin.TextCommand):
+    def run(self, edit):
+        pass
+
 class ViMoveByCharactersInLine(sublime_plugin.TextCommand):
     def run(self, edit, forward = True, extend = False, visual = False):
         delta = 1 if forward else -1


### PR DESCRIPTION
For example, `cc`, `cj`, `S`, and `c12G` should all leave the insert cursor on a correctly indented column.

Fixes #50
