### PR TITLE
Paste over visual selections like Vim

### DIFF
--- a/vintage.py
+++ b/vintage.py
@@ -765,7 +765,8 @@ class ViPasteRight(sublime_plugin.TextCommand):
             return pt + 1
 
     def run(self, edit, register = '"'):
-        transform_selection(self.view, lambda pt: self.advance(pt))
+        if not self.view.has_non_empty_selection_region():
+            transform_selection(self.view, lambda pt: self.advance(pt))
         self.view.run_command('paste_from_register', {'forward': True, 'register': register})
 
 class ViPasteLeft(sublime_plugin.TextCommand):
@@ -845,6 +846,9 @@ class PasteFromRegisterCommand(sublime_plugin.TextCommand):
         if not text:
             sublime.status_message("Undefined register" + register)
             return
+
+        if self.view.has_non_empty_selection_region():
+            self.view.run_command('vi_delete')
 
         regions = [r for r in self.view.sel()]
         new_sel = []

--- a/vintage.py
+++ b/vintage.py
@@ -765,9 +765,11 @@ class ViPasteRight(sublime_plugin.TextCommand):
             return pt + 1
 
     def run(self, edit, register = '"'):
-        if not self.view.has_non_empty_selection_region():
+        visual_mode = self.view.has_non_empty_selection_region()
+        if not visual_mode:
             transform_selection(self.view, lambda pt: self.advance(pt))
-        self.view.run_command('paste_from_register', {'forward': True, 'register': register})
+        self.view.run_command('paste_from_register', {'forward': not visual_mode,
+                                                      'register': register})
 
 class ViPasteLeft(sublime_plugin.TextCommand):
     # Ensure the register is picked up from g_input_state, and that it'll be


### PR DESCRIPTION
The text in the register _replaces_ the selection(s) and the text that was in the selections is put in that same register.

Fixes #9
