### PR TITLE
Fix bug that caused deletes to erroneously left_delete

### DIFF
--- a/vintage.py
+++ b/vintage.py
@@ -729,9 +729,10 @@ class Sequence(sublime_plugin.TextCommand):
 
 class ViDelete(sublime_plugin.TextCommand):
     def run(self, edit, register = '"'):
-        set_register(self.view, register, forward=False)
-        set_register(self.view, '1', forward=False)
-        self.view.run_command('left_delete')
+        if self.view.has_non_empty_selection_region():
+            set_register(self.view, register, forward=False)
+            set_register(self.view, '1', forward=False)
+            self.view.run_command('left_delete')
 
 class ViLeftDelete(sublime_plugin.TextCommand):
     def run(self, edit, register = '"'):
@@ -864,8 +865,7 @@ class PasteFromRegisterCommand(sublime_plugin.TextCommand):
             sublime.status_message("Undefined register" + register)
             return
 
-        if self.view.has_non_empty_selection_region():
-            self.view.run_command('vi_delete')
+        self.view.run_command('vi_delete')
 
         regions = [r for r in self.view.sel()]
         new_sel = []


### PR DESCRIPTION
For instance, `dtz` would left_delete if there was no "z" on the line.

fixes #78
