### PR TITLE
Add "vintage_clipboard" option to provide basic control over copy/paste operations

### DIFF
--- a/vintage.py
+++ b/vintage.py
@@ -829,7 +829,7 @@ def set_register(view, register, forward):
 
     # FIXME: Potential performance problem?
     prefs = sublime.load_settings("Preferences.sublime-settings")
-    use_sys_clipboard = prefs.get('vintage_clipboard', '')
+    use_sys_clipboard = prefs.get('vintage_clipboard', '') == 'unnamed'
 
     if use_sys_clipboard or register in ('*', '+'):
         sublime.set_clipboard(text)

--- a/vintage.py
+++ b/vintage.py
@@ -827,9 +827,7 @@ def set_register(view, register, forward):
 
     text = '\n'.join(text)
 
-    # FIXME: Potential performance problem?
-    prefs = sublime.load_settings("Preferences.sublime-settings")
-    use_sys_clipboard = prefs.get('vintage_clipboard', '') == 'unnamed'
+    use_sys_clipboard = view.settings().get('vintage_use_clipboard', False)
 
     if use_sys_clipboard or register in ('*', '+'):
         sublime.set_clipboard(text)

--- a/vintage.py
+++ b/vintage.py
@@ -827,7 +827,7 @@ def set_register(view, register, forward):
 
     text = '\n'.join(text)
 
-    use_sys_clipboard = view.settings().get('vintage_use_clipboard', False)
+    use_sys_clipboard = view.settings().get('vintage_use_clipboard', False) is True
 
     if use_sys_clipboard or register in ('*', '+'):
         sublime.set_clipboard(text)

--- a/vintage.py
+++ b/vintage.py
@@ -827,9 +827,17 @@ def set_register(view, register, forward):
 
     text = "\n".join(text)
 
-    if register == '*' or register == '+':
+    # FIXME: Potential performance problem?
+    prefs = sublime.load_settings("Preferences.sublime-settings")
+    use_sys_clipboard = prefs.get('vintage_clipboard', '')
+
+    if use_sys_clipboard or register in ('*', '+'):
         sublime.set_clipboard(text)
-    elif register == '%':
+        # If the system's clipboard is used, Vim always propagates the data to
+        # the unnamed register too.
+        register = '"'
+
+    if register == '%':
         pass
     else:
         reg = register.lower()

--- a/vintage.py
+++ b/vintage.py
@@ -825,7 +825,7 @@ def set_register(view, register, forward):
         text.append(view.substr(s))
         regions.append(s)
 
-    text = "\n".join(text)
+    text = '\n'.join(text)
 
     # FIXME: Potential performance problem?
     prefs = sublime.load_settings("Preferences.sublime-settings")
@@ -863,7 +863,7 @@ def get_register(view, register):
         return None
 
 def has_register(register):
-    if register in ["%", "*", "+"]:
+    if register in ['%', '*', '+']:
         return True
     else:
         return register in g_registers


### PR DESCRIPTION
`vintage_clipboard` lives in _Preferences.sublime-settings_.

**Values**:

`unnamed`: All copy operations propagate to sytem's clipboard in addition to the unnamed register.

Additional fixes:

All explicit copy operations into the system clipboard (`"*y`, `"+y`) propagate to the unnamed register too. This is consistent with Vim's behavior.
