### PR TITLE
Visual mode I and A

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -77,6 +77,14 @@
 		"context": [{"key": "setting.command_mode"}]
 	},
 
+	{ "keys": ["I"], "command": "enter_insert_mode",
+		"args": {"insert_command": "shrink_selections_to_beginning"},
+		"context": [
+			{"key": "setting.command_mode"},
+			{"key": "selection_empty", "operator": "equal", "operand": false}
+		]
+	},
+
 	{ "keys": ["a"], "command": "enter_insert_mode", "args":
 		{"insert_command": "move", "insert_args": {"by": "characters", "forward": true} },
 		"context":
@@ -89,6 +97,14 @@
 	{ "keys": ["A"], "command": "enter_insert_mode", "args":
 		{"insert_command": "move_to", "insert_args": {"to": "hardeol"} },
 		"context": [{"key": "setting.command_mode"}]
+	},
+
+	{ "keys": ["A"], "command": "enter_insert_mode",
+		"args": {"insert_command": "shrink_selections_to_end"},
+		"context": [
+			{"key": "setting.command_mode"},
+			{"key": "selection_empty", "operator": "equal", "operand": false}
+		]
 	},
 
 	{ "keys": ["o"], "command": "enter_insert_mode", "args":

--- a/vintage.py
+++ b/vintage.py
@@ -721,6 +721,25 @@ class ShrinkSelections(sublime_plugin.TextCommand):
     def run(self, edit):
         transform_selection_regions(self.view, self.shrink)
 
+class ShrinkSelectionsToBeginning(sublime_plugin.TextCommand):
+    def shrink(self, r):
+        return sublime.Region(r.begin())
+
+    def run(self, edit, register = '"'):
+        transform_selection_regions(self.view, self.shrink)
+
+class ShrinkSelectionsToEnd(sublime_plugin.TextCommand):
+    def shrink(self, r):
+        end = r.end()
+        if self.view.substr(end - 1) == u'\n':
+            # For linewise selections put the cursor *before* the line break
+            return sublime.Region(end - 1)
+        else:
+            return sublime.Region(end)
+
+    def run(self, edit, register = '"'):
+        transform_selection_regions(self.view, self.shrink)
+
 # Sequence is used as part of glue_marked_undo_groups: the marked undo groups
 # are rewritten into a single sequence command, that accepts all the previous
 # commands


### PR DESCRIPTION
This is consistent with Vim's behavior in visual block mode and in some cases for regular visual mode.

As mentioned in #82, there are some cases in which this is different than Vim, but reproducing that behavior wouldn't really be useful...
