### PR TITLE
Prevent cw and cW from eating the word after whitespace

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -439,10 +439,10 @@
 		"context": [{"key": "setting.command_mode"}]
 	},
 
-	// Make cw act like ce
+	// Make cw act kinda like ce
 	{ "keys": ["w"], "command": "set_motion", "args": {
-		"motion": "move",
-		"motion_args": {"by": "stops", "word_end": true, "punct_end": true, "empty_line": true, "forward": true, "extend": true },
+		"motion": "vi_extend_to_end_of_whitespace_or_word",
+		"motion_args": {"repeat": 1},
 		"inclusive": true,
 		"clip_to_line": true },
 		"context":
@@ -452,10 +452,10 @@
 		]
 	},
 
-	// Make cW act like cE
+	// Make cW act kinda like cE
 	{ "keys": ["W"], "command": "set_motion", "args": {
-		"motion": "move",
-		"motion_args": {"by": "stops", "word_end": true, "punct_end": true, "empty_line": true, "separators": "", "forward": true, "extend": true },
+		"motion": "vi_extend_to_end_of_whitespace_or_word",
+		"motion_args": {"repeat": 1, "separators": ""},
 		"inclusive": true,
 		"clip_to_line": true },
 		"context":


### PR DESCRIPTION
Using cw or cW from whitespace will delete only the whitespace before entering insert mode in Vim.  Previously Vintage would delete the word after the whitespace as well.  This fixes that.
