### PR TITLE
Fix behavior of commands like '4>' and '4<'

### DIFF
--- a/vintage.py
+++ b/vintage.py
@@ -8,6 +8,7 @@ MOTION_MODE_LINE = 2
 
 # Registers are used for clipboards and macro storage
 g_registers = {}
+REGISTER_NULL = '_'
 
 # Represents the current input state. The primary commands that interact with
 # this are:
@@ -831,6 +832,11 @@ class ViPasteLeft(ViPrefixableCommand):
                                                       'register': register})
 
 def set_register(view, register, forward):
+    if register == REGISTER_NULL:
+        # This is the null register; do nothing.
+        # More info in Vim: :help "_
+        return
+
     delta = 1
     if not forward:
         delta = -1
@@ -865,6 +871,11 @@ def set_register(view, register, forward):
             g_registers[reg] = text
 
 def get_register(view, register):
+    if register == REGISTER_NULL:
+        # This is the null register; do nothing.
+        # More info in Vim: :help "_
+        return
+
     use_sys_clipboard = view.settings().get('vintage_use_clipboard', False) == True
     register = register.lower()
     if register == '%':


### PR DESCRIPTION
Previous Behavior:

Let's assume we have a code block, and we have selected the entire block:

```
foo()
{
    bar()
}
```

Selecting the entire block and entering the command '>>' results in the output

```
    foo()
    {
        bar()
    }
```

Which is the same as vim. But if we select the original block and issue the command '3>', we see the result:

```
            foo()
    {
        bar()
    }
```

Wheras, the same command issued through vim would result in:

```
            foo()
            {
                bar()
            }
```

After doing a little investigating, I realized that "3>" calls the "vi_indent" command three times.

The first time, it indents the entire block of text and deselects it. Since the caret is only on the first line for the second and third time the "vi_indent" function is called, only the first line gets indented.

The real proper fix for this bug would be to not call "transform_selection_regions" until the last call of vi_indent but this seemed like a simpler hack.
