### PR TITLE
Adds visual upper case and visual lower case emulation like in vim

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -130,6 +130,23 @@
 		"context": [{"key": "setting.command_mode"}, {"key": "setting.vintage_ctrl_keys"}]
 	},
 
+
+	{ "keys": ["u"], "command": "visual_lower_case",
+		"context":
+		[
+			{"key": "setting.command_mode"},
+			{"key": "selection_empty", "operator": "equal", "operand": false, "match_all": false}
+		]
+	},
+
+	{ "keys": ["U"], "command": "visual_upper_case",
+		"context":
+		[
+			{"key": "setting.command_mode"},
+			{"key": "selection_empty", "operator": "equal", "operand": false, "match_all": false}
+		]
+	},
+
 	{ "keys": ["v"], "command": "enter_visual_mode",
 		"context": [{"key": "setting.command_mode"}]
 	},

--- a/vintage.py
+++ b/vintage.py
@@ -740,6 +740,16 @@ class ShrinkSelectionsToEnd(sublime_plugin.TextCommand):
     def run(self, edit, register = '"'):
         transform_selection_regions(self.view, self.shrink)
 
+class VisualUpperCase(sublime_plugin.TextCommand):
+    def run(self, edit):
+        self.view.run_command("upper_case")
+        self.view.run_command("exit_visual_mode")
+
+class VisualLowerCase(sublime_plugin.TextCommand):
+    def run(self, edit):
+        self.view.run_command("lower_case")
+        self.view.run_command("exit_visual_mode")
+
 # Sequence is used as part of glue_marked_undo_groups: the marked undo groups
 # are rewritten into a single sequence command, that accepts all the previous
 # commands


### PR DESCRIPTION
When in visual mode pressing "U" should upper case the selection and exit visual mode, and pressing "u" in visual mode should lower case the selection and exit visual mode. This pull request implements this.
