### PR TITLE
ci<quote> operates on caret's line only

### DIFF
--- a/vintage_motions.py
+++ b/vintage_motions.py
@@ -291,22 +291,21 @@ class ViExpandToQuotes(sublime_plugin.TextCommand):
         first_quote = line_text.find(character)
         closing_quote = None
 
-        pivot = max((caret_pos_in_line, first_quote))
-
-        if pivot > -1:
-            # If the caret's on a quote character, don't look for a second
-            # quote past it. This ensures we favor any quoted text before the
-            # caret over quoted text after it, as Vim does.
-            if (line_text[caret_pos_in_line] == character and
-                caret_pos_in_line == first_quote):
-                    closing_quote = line_text.find(character, pivot + 1)
-            else:
-                closing_quote = line_text.find(character, pivot)
+        # Look for a closing quote after the first quote.
+        if ((line_text[caret_pos_in_line] == character and
+             first_quote == caret_pos_in_line) or
+             (first_quote > caret_pos_in_line)):
+                closing_quote = line_text.find(character, first_quote + 1)
+        # The caret may be on a quote character, so don't look past it.
+        # This ensures we favor quoted text before the caret over quoted
+        # text after it, as Vim does.
+        else:
+            closing_quote = line_text.find(character, caret_pos_in_line)
 
         # No quoted text --do nothing (Vim).
         # TODO: Vintage will enter insert mode after this, whereas it should
         # stay in command mode as Vim does.
-        if not closing_quote:
+        if not closing_quote or closing_quote == -1:
             return r
 
         # Quoted text is before the caret --do nothing (Vim).

--- a/vintage_motions.py
+++ b/vintage_motions.py
@@ -307,6 +307,7 @@ class ViExpandToQuotes(sublime_plugin.TextCommand):
         # The quoted text is after the caret, so advance there as Vim does.
         if first_quote > caret_pos_in_line:
             p = line_begin + first_quote + 1
+        # If the caret is on a quote character, go back so the action succeeds.
         elif line_text[caret_pos_in_line] == character:
             p = line_begin + caret_pos_in_line - 1
 

--- a/vintage_motions.py
+++ b/vintage_motions.py
@@ -306,9 +306,10 @@ class ViExpandToQuotes(sublime_plugin.TextCommand):
         p = r.b
         # The quoted text is after the caret, so advance there as Vim does.
         if first_quote > caret_pos_in_line:
-            p = line_begin + first_quote + 1
+            p = line_begin + first_quote
         # If the caret is on a quote character, go back so the action succeeds.
-        elif line_text[caret_pos_in_line] == character:
+        elif (line_text[caret_pos_in_line] == character and
+              line_text[caret_pos_in_line+1] != character):
             p = line_begin + caret_pos_in_line - 1
 
         a = p

--- a/vintage_motions.py
+++ b/vintage_motions.py
@@ -305,7 +305,7 @@ class ViExpandToQuotes(sublime_plugin.TextCommand):
         # No quoted text --do nothing (Vim).
         # TODO: Vintage will enter insert mode after this, whereas it should
         # stay in command mode as Vim does.
-        if not closing_quote or closing_quote == -1:
+        if closing_quote == -1:
             return r
 
         # Quoted text is before the caret --do nothing (Vim).

--- a/vintage_motions.py
+++ b/vintage_motions.py
@@ -299,8 +299,8 @@ class ViExpandToQuotes(sublime_plugin.TextCommand):
         # none of the selections performed a text object operation --in that
         # case we should stay in command mode.
         if (not second_quote or
-            (line_text.find(character, caret_pos_in_line) == -1 and
-             line_text[caret_pos_in_line] != character)):
+            (line_text[caret_pos_in_line] != character and
+             line_text.find(character, caret_pos_in_line) == -1)):
                 return r
 
         p = r.b

--- a/vintage_motions.py
+++ b/vintage_motions.py
@@ -299,19 +299,22 @@ class ViExpandToQuotes(sublime_plugin.TextCommand):
         # none of the selections performed a text object operation --in that
         # case we should stay in command mode.
         if (not second_quote or
-            line_text.find(character, caret_pos_in_line) == -1):
+            (line_text.find(character, caret_pos_in_line) == -1 and
+             not line_text[caret_pos_in_line] == character)):
                 return r
 
         p = r.b
         # The quoted text is after the caret, so advance there as Vim does.
         if first_quote > caret_pos_in_line:
             p = line_begin + first_quote + 1
+        elif line_text[caret_pos_in_line] == character:
+            p = line_begin + caret_pos_in_line - 1
 
         a = p
-        b = p
         while a >= line_begin and not self.compare_quote(character, a):
             a -= 1
 
+        b = a + 1
         while b < line_end and not self.compare_quote(character, b):
             b += 1
 

--- a/vintage_motions.py
+++ b/vintage_motions.py
@@ -296,12 +296,12 @@ class ViExpandToQuotes(sublime_plugin.TextCommand):
         if pivot > -1:
             # If the caret's on a quote character, don't look for a second
             # quote past it. This ensures we favor any quoted text before the
-            # over quoted text after it.
+            # caret over quoted text after it, as Vim does.
             if (line_text[caret_pos_in_line] == character and
-                caret_pos_in_line != first_quote):
-                    closing_quote = caret_pos_in_line
+                caret_pos_in_line == first_quote):
+                    closing_quote = line_text.find(character, pivot + 1)
             else:
-                closing_quote = line_text.find(character, pivot + 1)
+                closing_quote = line_text.find(character, pivot)
 
         # No quoted text --do nothing (Vim).
         # TODO: Vintage will enter insert mode after this, whereas it should

--- a/vintage_motions.py
+++ b/vintage_motions.py
@@ -300,7 +300,7 @@ class ViExpandToQuotes(sublime_plugin.TextCommand):
         # case we should stay in command mode.
         if (not second_quote or
             (line_text.find(character, caret_pos_in_line) == -1 and
-             not line_text[caret_pos_in_line] == character)):
+             line_text[caret_pos_in_line] != character)):
                 return r
 
         p = r.b


### PR DESCRIPTION
Related to #123.
## Fixes
- `ci"` restricts search to caret's line
- avoid infinite loop if `ci"` is issued on a line without quotes in it
- if the quoted text is before the caret, abort (as in Vim)
## Bugs
- if the command is aborted, Vintage will enter insert mode. If none of the
  selections performed any changes, we should stay in command mode. Note that this bug is unrelated to this patch; it's been there for a while, it just affects this command too.
