### PR TITLE
support vi's ''/`` (jump to position before last jump)

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -276,6 +276,10 @@
 		"context": [{"key": "setting.command_mode"}]
 	},
 
+	{ "keys": ["'", "."], "command": "vi_goto_last_edit",
+		"context": [{"key": "setting.command_mode"}]
+	},
+
 	{ "keys": ["~"], "command": "set_action_motion", "args": {
 		"action": "swap_case",
 		"motion": "vi_move_by_characters_in_line",

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -276,10 +276,6 @@
 		"context": [{"key": "setting.command_mode"}]
 	},
 
-	{ "keys": ["'", "."], "command": "vi_goto_last_edit",
-		"context": [{"key": "setting.command_mode"}]
-	},
-
 	{ "keys": ["~"], "command": "set_action_motion", "args": {
 		"action": "swap_case",
 		"motion": "vi_move_by_characters_in_line",

--- a/vintage.py
+++ b/vintage.py
@@ -993,6 +993,10 @@ class ViSetBookmark(sublime_plugin.TextCommand):
 
 class ViSelectBookmark(sublime_plugin.TextCommand):
     def run(self, edit, character, select_bol=False):
+        if character == '.':
+            self.view.run_command('vi_goto_last_edit')
+            return
+
         self.view.run_command('select_all_bookmarks', {'name': "bookmark_" + character})
         if select_bol:
             sels = list(self.view.sel())
@@ -1087,3 +1091,56 @@ class MoveGroupFocus(sublime_plugin.WindowCommand):
             self.window.focus_group(matches.next())
         except StopIteration:
             return
+
+
+LAST_EDITS_SETTING = 'last_edits'
+
+
+class ViRecordLastEdit(sublime_plugin.EventListener):
+    def on_modified(self, view):
+        last_edits = view.settings().get(LAST_EDITS_SETTING, {}) 
+        edit_position = view.sel()[0] 
+        last_edits[str(view.id())] = {'a': edit_position.a, 'b': edit_position.b}
+        view.settings().set(LAST_EDITS_SETTING, last_edits) 
+
+ 
+class ViGotoLastEdit(sublime_plugin.TextCommand): 
+    # The position the cursor was at before the command fired. Saved when the
+    # command is run, so that if the user runs the command again before making
+    # another edit in the file, the cursor returns to its original position.
+    original_position = None
+
+    def move_cursor_to_region(self, region):
+        """ Clear the cursor's position and move it to `region`. """
+        cursor = self.view.sel()
+        self.original_position = cursor[0] 
+        cursor.clear()
+        cursor.add(region)
+        self.view.show(region) 
+
+    def run(self, edit): 
+        """
+        If there was a last edit recorded for the view, store the current
+        position as self.original_position and move the cursor to the position
+        of the last edit.
+
+        If the cursor is currently at the same position as the last edit, and
+        there `self.original_position` is available, then return the cursor to
+        its original position.
+        """ 
+        last_edits = self.view.settings().get(LAST_EDITS_SETTING, {})
+        last_edit = last_edits.get(str(self.view.id()), None)
+        current_position = self.view.sel()[0]
+
+        if last_edit is None:
+            return
+
+        last_edit_region = sublime.Region(
+            long(last_edit['a']), long(last_edit['b']))
+
+        if self.original_position is not None \
+            and current_position == last_edit_region:
+            self.move_cursor_to_region(self.original_position)
+            return
+
+        self.move_cursor_to_region(last_edit_region)

--- a/vintage.py
+++ b/vintage.py
@@ -993,10 +993,6 @@ class ViSetBookmark(sublime_plugin.TextCommand):
 
 class ViSelectBookmark(sublime_plugin.TextCommand):
     def run(self, edit, character, select_bol=False):
-        if character == '.':
-            self.view.run_command('vi_goto_last_edit')
-            return
-
         self.view.run_command('select_all_bookmarks', {'name': "bookmark_" + character})
         if select_bol:
             sels = list(self.view.sel())
@@ -1098,13 +1094,13 @@ LAST_EDITS_SETTING = 'last_edits'
 
 class ViRecordLastEdit(sublime_plugin.EventListener):
     def on_modified(self, view):
-        last_edits = view.settings().get(LAST_EDITS_SETTING, {}) 
-        edit_position = view.sel()[0] 
+        last_edits = view.settings().get(LAST_EDITS_SETTING, {})
+        edit_position = view.sel()[0]
         last_edits[str(view.id())] = {'a': edit_position.a, 'b': edit_position.b}
-        view.settings().set(LAST_EDITS_SETTING, last_edits) 
+        view.settings().set(LAST_EDITS_SETTING, last_edits)
 
- 
-class ViGotoLastEdit(sublime_plugin.TextCommand): 
+
+class ViGotoLastEdit(sublime_plugin.TextCommand):
     # The position the cursor was at before the command fired. Saved when the
     # command is run, so that if the user runs the command again before making
     # another edit in the file, the cursor returns to its original position.
@@ -1113,12 +1109,12 @@ class ViGotoLastEdit(sublime_plugin.TextCommand):
     def move_cursor_to_region(self, region):
         """ Clear the cursor's position and move it to `region`. """
         cursor = self.view.sel()
-        self.original_position = cursor[0] 
+        self.original_position = cursor[0]
         cursor.clear()
         cursor.add(region)
-        self.view.show(region) 
+        self.view.show(region)
 
-    def run(self, edit): 
+    def run(self, edit):
         """
         If there was a last edit recorded for the view, store the current
         position as self.original_position and move the cursor to the position
@@ -1127,7 +1123,7 @@ class ViGotoLastEdit(sublime_plugin.TextCommand):
         If the cursor is currently at the same position as the last edit, and
         there `self.original_position` is available, then return the cursor to
         its original position.
-        """ 
+        """
         last_edits = self.view.settings().get(LAST_EDITS_SETTING, {})
         last_edit = last_edits.get(str(self.view.id()), None)
         current_position = self.view.sel()[0]

--- a/vintage.py
+++ b/vintage.py
@@ -1107,7 +1107,7 @@ class ViGotoLastEdit(sublime_plugin.TextCommand):
     def move_cursor_to_region_set(self, region_set):
         """ Clear the cursor's position and move it to `region_set`. """
         sel = self.view.sel()
-        self.original_position = [r for r in sel]
+        self.original_position = list(sel)
         sel.clear()
         for region in region_set:
             sel.add(region)
@@ -1124,7 +1124,7 @@ class ViGotoLastEdit(sublime_plugin.TextCommand):
         its original position.
         """
         last_edit = self.view.get_regions(LAST_EDIT_KEY)
-        current_position = [r for r in self.view.sel()]
+        current_position = list(self.view.sel())
 
         if not last_edit:
             return

--- a/vintage.py
+++ b/vintage.py
@@ -1111,8 +1111,9 @@ class ViGotoLastEdit(sublime_plugin.TextCommand):
         sel.clear()
         for region in region_set:
             sel.add(region)
+        self.view.show(region_set[0])
 
-    def run(self, edit): 
+    def run(self, edit):
         """
         If there was a last edit recorded for the view, save the current
         position as `self.original_position` and move the cursor to the position
@@ -1125,8 +1126,8 @@ class ViGotoLastEdit(sublime_plugin.TextCommand):
         last_edit = self.view.get_regions(LAST_EDIT_KEY)
         current_position = [r for r in self.view.sel()]
 
-        if last_edit is None:
-            return 
+        if not last_edit:
+            return
 
         if self.original_position is not None \
                 and current_position == last_edit:
@@ -1134,3 +1135,4 @@ class ViGotoLastEdit(sublime_plugin.TextCommand):
             return
 
         self.move_cursor_to_region_set(last_edit)
+

--- a/vintage.py
+++ b/vintage.py
@@ -1089,15 +1089,13 @@ class MoveGroupFocus(sublime_plugin.WindowCommand):
             return
 
 
-LAST_EDITS_SETTING = 'last_edits'
+LAST_EDIT_KEY = 'vintage_last_edit'
 
 
 class ViRecordLastEdit(sublime_plugin.EventListener):
     def on_modified(self, view):
-        last_edits = view.settings().get(LAST_EDITS_SETTING, {})
-        edit_position = view.sel()[0]
-        last_edits[str(view.id())] = {'a': edit_position.a, 'b': edit_position.b}
-        view.settings().set(LAST_EDITS_SETTING, last_edits)
+        """ Record the cursor's position at the last edit in the view. """
+        view.add_regions(LAST_EDIT_KEY, [s for s in view.sel()], '')
 
 
 class ViGotoLastEdit(sublime_plugin.TextCommand):
@@ -1106,37 +1104,33 @@ class ViGotoLastEdit(sublime_plugin.TextCommand):
     # another edit in the file, the cursor returns to its original position.
     original_position = None
 
-    def move_cursor_to_region(self, region):
-        """ Clear the cursor's position and move it to `region`. """
-        cursor = self.view.sel()
-        self.original_position = cursor[0]
-        cursor.clear()
-        cursor.add(region)
-        self.view.show(region)
+    def move_cursor_to_region_set(self, region_set):
+        """ Clear the cursor's position and move it to `region_set`. """
+        sel = self.view.sel()
+        self.original_position = [r for r in sel]
+        sel.clear()
+        for region in region_set:
+            sel.add(region)
 
-    def run(self, edit):
+    def run(self, edit): 
         """
-        If there was a last edit recorded for the view, store the current
-        position as self.original_position and move the cursor to the position
+        If there was a last edit recorded for the view, save the current
+        position as `self.original_position` and move the cursor to the position
         of the last edit.
 
         If the cursor is currently at the same position as the last edit, and
         there `self.original_position` is available, then return the cursor to
         its original position.
         """
-        last_edits = self.view.settings().get(LAST_EDITS_SETTING, {})
-        last_edit = last_edits.get(str(self.view.id()), None)
-        current_position = self.view.sel()[0]
+        last_edit = self.view.get_regions(LAST_EDIT_KEY)
+        current_position = [r for r in self.view.sel()]
 
         if last_edit is None:
-            return
-
-        last_edit_region = sublime.Region(
-            long(last_edit['a']), long(last_edit['b']))
+            return 
 
         if self.original_position is not None \
-            and current_position == last_edit_region:
-            self.move_cursor_to_region(self.original_position)
+                and current_position == last_edit:
+            self.move_cursor_to_region_set(self.original_position)
             return
 
-        self.move_cursor_to_region(last_edit_region)
+        self.move_cursor_to_region_set(last_edit)

--- a/vintage.py
+++ b/vintage.py
@@ -1134,51 +1134,7 @@ class MoveGroupFocus(sublime_plugin.WindowCommand):
         except StopIteration:
             return
 
-
-LAST_EDIT_KEY = 'vintage_last_edit'
-
-
 class ViRecordLastEdit(sublime_plugin.EventListener):
     def on_modified(self, view):
         """ Record the cursor's position at the last edit in the view. """
-        view.add_regions(LAST_EDIT_KEY, [s for s in view.sel()], '')
-
-
-class ViGotoLastEdit(sublime_plugin.TextCommand):
-    # The position the cursor was at before the command fired. Saved when the
-    # command is run, so that if the user runs the command again before making
-    # another edit in the file, the cursor returns to its original position.
-    original_position = None
-
-    def move_cursor_to_region_set(self, region_set):
-        """ Clear the cursor's position and move it to `region_set`. """
-        sel = self.view.sel()
-        self.original_position = list(sel)
-        sel.clear()
-        for region in region_set:
-            sel.add(region)
-        self.view.show(region_set[0])
-
-    def run(self, edit):
-        """
-        If there was a last edit recorded for the view, save the current
-        position as `self.original_position` and move the cursor to the position
-        of the last edit.
-
-        If the cursor is currently at the same position as the last edit, and
-        there `self.original_position` is available, then return the cursor to
-        its original position.
-        """
-        last_edit = self.view.get_regions(LAST_EDIT_KEY)
-        current_position = list(self.view.sel())
-
-        if not last_edit:
-            return
-
-        if self.original_position is not None \
-                and current_position == last_edit:
-            self.move_cursor_to_region_set(self.original_position)
-            return
-
-        self.move_cursor_to_region_set(last_edit)
-
+        ViSetBookmark._run(view, ".")


### PR DESCRIPTION
This is done through a refactor of `ViSetBookmark`.

@abrookins "goto last edit" (pull #111) is then rewritten based on this refactor. The behaviour of `'./`.` is slightly tweaked: `'./`.` still jumps to the last edit, as pull #111 does, but to jump back, the new `''/``` is used, instead of `'./`.` in pull #111. This is closer to vi's behaviour.

PS. accepting this pull request implicitly merges pull #111.
