### PR TITLE
Moved up, down, left and right from the platform specific keymaps.

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,24 +1,4 @@
 [
-    { "keys": ["left"], "command": "set_motion", "args": {
-        "motion": "vi_move_by_characters_in_line",
-        "motion_args": {"forward": false, "extend": true }},
-        "context": [{"key": "setting.command_mode"}]
-    },
-    { "keys": ["right"], "command": "set_motion", "args": {
-        "motion": "vi_move_by_characters_in_line",
-        "motion_args": {"forward": true, "extend": true, "visual": false }},
-        "context": [{"key": "setting.command_mode"}]
-    },
-    { "keys": ["up"], "command": "set_motion", "args": {
-        "motion": "move",
-        "motion_args": {"by": "lines", "forward": false, "extend": true }},
-        "context": [{"key": "setting.command_mode"}]
-    },
-    { "keys": ["down"], "command": "set_motion", "args": {
-        "motion": "move",
-        "motion_args": {"by": "lines", "forward": true, "extend": true }},
-        "context": [{"key": "setting.command_mode"}]
-    },
 
     { "keys": ["ctrl+left"], "command": "set_motion", "args": {
         "motion": "move",

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -28,27 +28,6 @@
         ]
     },
 
-    { "keys": ["left"], "command": "set_motion", "args": {
-        "motion": "vi_move_by_characters_in_line",
-        "motion_args": {"forward": false, "extend": true }},
-        "context": [{"key": "setting.command_mode"}]
-    },
-    { "keys": ["right"], "command": "set_motion", "args": {
-        "motion": "vi_move_by_characters_in_line",
-        "motion_args": {"forward": true, "extend": true, "visual": false }},
-        "context": [{"key": "setting.command_mode"}]
-    },
-    { "keys": ["up"], "command": "set_motion", "args": {
-        "motion": "move",
-        "motion_args": {"by": "lines", "forward": false, "extend": true }},
-        "context": [{"key": "setting.command_mode"}]
-    },
-    { "keys": ["down"], "command": "set_motion", "args": {
-        "motion": "move",
-        "motion_args": {"by": "lines", "forward": true, "extend": true }},
-        "context": [{"key": "setting.command_mode"}]
-    },
-
     { "keys": ["alt+left"], "command": "set_motion", "args": {
         "motion": "move",
         "motion_args": {"by": "stops", "word_begin": true, "punct_begin": true, "empty_line": true, "forward": false, "extend": true }},

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,25 +1,4 @@
 [
-    { "keys": ["left"], "command": "set_motion", "args": {
-        "motion": "vi_move_by_characters_in_line",
-        "motion_args": {"forward": false, "extend": true }},
-        "context": [{"key": "setting.command_mode"}]
-    },
-    { "keys": ["right"], "command": "set_motion", "args": {
-        "motion": "vi_move_by_characters_in_line",
-        "motion_args": {"forward": true, "extend": true, "visual": false }},
-        "context": [{"key": "setting.command_mode"}]
-    },
-    { "keys": ["up"], "command": "set_motion", "args": {
-        "motion": "move",
-        "motion_args": {"by": "lines", "forward": false, "extend": true }},
-        "context": [{"key": "setting.command_mode"}]
-    },
-    { "keys": ["down"], "command": "set_motion", "args": {
-        "motion": "move",
-        "motion_args": {"by": "lines", "forward": true, "extend": true }},
-        "context": [{"key": "setting.command_mode"}]
-    },
-
     { "keys": ["ctrl+left"], "command": "set_motion", "args": {
         "motion": "move",
         "motion_args": {"by": "stops", "word_begin": true, "punct_begin": true, "empty_line": true, "forward": false, "extend": true }},

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1,4 +1,27 @@
 [
+	{ "keys": ["left"], "command": "set_motion", "args": {
+		"motion": "vi_move_by_characters_in_line",
+		"motion_args": {"forward": false, "extend": true }},
+		"context": [{"key": "setting.command_mode"}]
+	},
+	{ "keys": ["right"], "command": "set_motion", "args": {
+		"motion": "vi_move_by_characters_in_line",
+		"motion_args": {"forward": true, "extend": true, "visual": false }},
+		"context": [{"key": "setting.command_mode"}]
+	},
+	{ "keys": ["up"], "command": "set_motion", "args": {
+		"linewise": true,
+		"motion": "move",
+		"motion_args": {"by": "lines", "forward": false, "extend": true }},
+		"context": [{"key": "setting.command_mode"}]
+	},
+	{ "keys": ["down"], "command": "set_motion", "args": {
+		"linewise": true,
+		"motion": "move",
+		"motion_args": {"by": "lines", "forward": true, "extend": true }},
+		"context": [{"key": "setting.command_mode"}]
+	},
+
 	{ "keys": ["escape"], "command": "exit_insert_mode",
 		"context":
 		[


### PR DESCRIPTION
They were all the same anyway so is a better fit for the common
keymay. Also made up and down have the "linewise": true setting to
behave like j and k. This makes for example 4dj and 4d&lt;down&gt; work
the same.
