### PR TITLE
Fix for Issue #164: 's' after selecting text in visual mode off-by-one

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -852,9 +852,8 @@
 
 	{ "keys": ["s"], "command": "set_action_motion", "args": {
 		"action": "enter_insert_mode",
-		"action_args": {"insert_command": "vi_delete"},
-		"motion": "vi_move_by_characters_in_line",
-		"motion_args": {"forward": true, "extend": true, "visual": false }},
+		"action_args": {"insert_command": "right_delete"},
+		"motion": "expand_selection" },
 		"context": [{"key": "setting.command_mode"}]
 	},
 


### PR DESCRIPTION
Fix for https://github.com/sublimehq/Vintage/issues/164

One minor change to Default.sublime-keymap.
