### PR TITLE
bug(paste): Makes character-wise paste VIM-like.

### DIFF
--- a/vintage.py
+++ b/vintage.py
@@ -927,7 +927,7 @@ class PasteFromRegisterCommand(sublime_plugin.TextCommand):
                 self.view.erase(edit, sublime.Region(s.begin() + num,
                     s.end() + num))
                 num -= s.size()
-                new_sel.append(s.begin())
+                new_sel.append(s.begin() + len(text) - 1)
 
             offset += num
 


### PR DESCRIPTION
Currently, when pasting character-wise, the selection is kept at the beginning. In VIM, the behavior is placing the cursor at the end of the pasted content.

Example of current behavior:
  `d_o_g` - Denotes the cursor is under the letter "o" in "dog".
  `d>og<` - Denotes the selection is "og" in "dog".

  `>something<` - Let's yank(y) this selection "something".
  `_s_omething` - Place the cursor over "s"

  Put(p) in Sublime result:
  `s_s_omethingomething`

  Put(p) in VIM result:
  `ssomethin_g_omething`

This minor change fixes Sublime's character-wise put to behave like VIM's.
