### PR TITLE
add :x using the vi_save_and_exit command

### DIFF
--- a/Vintage.sublime-commands
+++ b/Vintage.sublime-commands
@@ -16,5 +16,9 @@
         "caption": ":$ - EOF",
         "command": "move_to",
         "args": {"to": "eof"}
+    },
+    {
+        "caption": ":x - Save And Exit",
+        "command": "vi_save_and_exit"
     }
 ]


### PR DESCRIPTION
Hello!

When I was learning vim in... vim, I often used `:x`. When I swapped to Sublime Text (still better although it's not really... optimised for it), I thought I wounldn't use it, but, I found myself often doing <kbd>ctrl+s, ctrl+w</kbd>

Just now, I looked a bit in the code of the Vintage package and find the `vi_save_and_exit` command. Why wasn't it added to the `.sublime-commands` file?

Matt